### PR TITLE
Update Xpano to 0.9.3

### DIFF
--- a/cz.krupkat.Xpano.yaml
+++ b/cz.krupkat.Xpano.yaml
@@ -93,8 +93,8 @@ modules:
     sources: 
       - type: git
         url: https://github.com/krupkat/xpano
-        tag: "v0.9.2"
-        commit: 521ffb6e7d13c8e1605f0233bad1916559ea5bf1
+        tag: "v0.9.3"
+        commit: 940df08add53b848bd56924bc359d17e050751b0
     config-opts:
       - -DNFD_PORTAL=ON
     post-install:


### PR DESCRIPTION
Latest release: https://github.com/krupkat/xpano/releases/tag/v0.9.3 with fixed appstream metadata (version number in xml was not consistent with the tag).